### PR TITLE
update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ func main() {
 	})
 
 	// 405 for PUT, PATCH, DELETE, etc.
-	m.Router.NotFound(strict.MethodNotAllowed, strict.NotFound)
+	m.NotFound(strict.MethodNotAllowed, strict.NotFound)
 
 	m.Run()
 }


### PR DESCRIPTION
it's better to use `*Martini.Router#NotFound` directly
